### PR TITLE
Fail to decode tuples when not all input consumed

### DIFF
--- a/tests/Properties/FoundationDB/Layer/Tuple.hs
+++ b/tests/Properties/FoundationDB/Layer/Tuple.hs
@@ -163,6 +163,14 @@ issue12 = describe "Max 8-byte encoded ints" $ do
     encodeTupleElems [Int $ negate $ 2^(64 :: Integer) - 1]
       `shouldBe` "\x0c\x00\x00\x00\x00\x00\x00\x00\x00"
 
+decodeInvalidBytes :: SpecWith ()
+decodeInvalidBytes = describe "decode invalid bytes" $ do
+  let err = Left "could not decode 1 bytes from the end of the bytestring"
+  it "decodeTupleElems with invalid tuple" $
+    decodeTupleElems "\x50" `shouldBe` err
+  it "decodeTupleElemsWPrefix with valid prefix but invalid tuple" $ do
+    decodeTupleElemsWPrefix "a" "a\x50" `shouldBe` err
+
 encodeDecodeSpecs :: SpecWith ()
 encodeDecodeSpecs = describe "Tuple encoding" $ do
   encodeDecode [] exampleEmpty "empty tuples"
@@ -195,6 +203,7 @@ encodeDecodeSpecs = describe "Tuple encoding" $ do
   -- doesn't roundtrip either.
   describeIntegerTypeCodes
   issue12
+  decodeInvalidBytes
 
 encodeDecodeProps :: SpecWith ()
 encodeDecodeProps = prop "decode . encode == id" $


### PR DESCRIPTION
I am not sure if this is a bug, but I found it unexpected: currently, when `decodeTupleElems` does not consume all the input then it returns only the tuple elements it managed to read, instead of failing.

This pull request changes that behaviour so that it fails instead.