### PR TITLE
Speed up decoding of bytes/string tuple elements.

### DIFF
--- a/bench/tuple/Main.hs
+++ b/bench/tuple/Main.hs
@@ -3,6 +3,7 @@
 module Main where
 
 import Data.ByteString (ByteString)
+import qualified Data.Text as T
 
 import FoundationDB.Versionstamp
 import FoundationDB.Layer.Tuple.Internal
@@ -11,6 +12,10 @@ import Gauge.Main
 
 mixedTuple :: ByteString
 mixedTuple = "\SOHsome_prefix\NUL\SOHsome_other_prefix\NUL3\NUL\NUL\NUL\NUL\NUL\NUL\NUL\SOH\NUL\STX\NUL\ETX\NAK\f"
+
+longTextTuple :: ByteString
+longTextTuple =
+  encodeTupleElems [Text (T.replicate 80000 "a")]
 
 main :: IO ()
 main =
@@ -51,6 +56,7 @@ main =
     [ bench "Tuple" (nf decodeTupleElems "\ENQ\SOHhello\NUL\NUL")
     , bench "Bytes" (nf decodeTupleElems "\SOHhello\NUL")
     , bench "Text"  (nf decodeTupleElems "\STXhello\NUL")
+    , bench "Text long" (nf decodeTupleElems longTextTuple)
     , bench "Int small pos" (nf decodeTupleElems "\SYN\EOT\NUL")
     , bench "Int small neg" (nf decodeTupleElems "\DC2\251\255")
     , bench "Int large pos" (nf decodeTupleElems "\FS\SOHk\204A\233\NUL\NUL\NUL")

--- a/foundationdb-haskell.cabal
+++ b/foundationdb-haskell.cabal
@@ -161,4 +161,5 @@ benchmark tuple-bench
                        , foundationdb-haskell
                        , gauge
                        , bytestring >= 0.10.8.2 && <0.11
+                       , text
   default-language:    Haskell2010


### PR DESCRIPTION
I thought that larger text elements in tuples were taking a long time to decode, so I tried making it faster.

Before this change (using the new benchmark I added in this pull request):

```
benchmarked decodeTupleElems/Text long
time                 107.3 ms   (103.4 ms .. 111.8 ms)
                     0.998 R²   (0.995 R² .. 1.000 R²)
mean                 103.7 ms   (102.6 ms .. 105.7 ms)
std dev              2.425 ms   (1.025 ms .. 3.537 ms)
```

and afterwards:

```
benchmarked decodeTupleElems/Text long
time                 16.89 ms   (16.46 ms .. 17.30 ms)
                     0.997 R²   (0.995 R² .. 0.998 R²)
mean                 18.14 ms   (17.77 ms .. 18.68 ms)
std dev              1.086 ms   (798.6 μs .. 1.428 ms)
variance introduced by outliers: 25% (moderately inflated)
```

I am no kind of Haskell optimisation expert, so I suppose it can be sped up even more, but this is a start.