### PR TITLE
Remove ResourceT, add MonadBaseControl instance

### DIFF
--- a/foundationdb-haskell.cabal
+++ b/foundationdb-haskell.cabal
@@ -88,10 +88,10 @@ library
                        , integer-gmp
                        , mtl
                        , random
-                       , resourcet
                        , text
                        , deepseq
-
+                       , monad-control
+                       , transformers-base
   build-tools:         c2hs
 
   -- Directories containing source files.

--- a/src/FoundationDB/Internal/Bindings.chs
+++ b/src/FoundationDB/Internal/Bindings.chs
@@ -36,12 +36,13 @@ module FoundationDB.Internal.Bindings (
   , databaseSetOption
   , databaseCreateTransaction
   -- * Transaction
-  , Transaction
+  , Transaction (..)
   , KeySelector (..)
   , keySelectorBytes
   , keySelectorTuple
   , tupleKeySelector
   , transactionDestroy
+  , transactionDestroyPtr
   , transactionSetOption
   , transactionSetReadVersion
   , transactionGetReadVersion
@@ -304,6 +305,10 @@ deriving instance Storable Transaction
 
 {#fun unsafe database_create_transaction as ^
   {`Database', alloca- `Transaction' peek*} -> `CFDBError' CFDBError#}
+
+
+foreign import ccall "fdbc_wrapper.h &fdb_transaction_destroy"
+  transactionDestroyPtr :: FunPtr (Ptr a -> IO ())
 
 {#fun unsafe transaction_destroy as ^ {`Transaction'} -> `()'#}
 


### PR DESCRIPTION
All of our usage of ResourceT can be easily handled by ForeignPtr,
with less complexity. This allows us to add a MonadBaseControl
instance, which lets me use streamly in my project.