### PR TITLE
Add Eq instances for DatabasePtr and Database.

### DIFF
--- a/src/FoundationDB/Internal/Bindings.chs
+++ b/src/FoundationDB/Internal/Bindings.chs
@@ -203,6 +203,7 @@ futureGetKey f = do
 -- | Handle to the underlying C API client state.
 {#pointer *FDBDatabase as DatabasePtr newtype #}
 
+deriving instance Eq DatabasePtr
 deriving instance Show DatabasePtr
 deriving instance Storable DatabasePtr
 

--- a/src/FoundationDB/Internal/Database.hs
+++ b/src/FoundationDB/Internal/Database.hs
@@ -33,7 +33,7 @@ defaultOptions = FoundationDBOptions FDB.currentAPIVersion Nothing [] []
 data Database = Database
   { databasePtr :: FDB.DatabasePtr
   , databaseFoundationDBOptions :: FoundationDBOptions
-  } deriving (Show)
+  } deriving (Show, Eq)
 
 -- | Returns the API version that was specified in the 'apiVersion' field when
 -- the FDB client was initialized.


### PR DESCRIPTION
The C FDB library does not allow more than one DatabasePtr value per
process, but it is sometimes convenient to have Eq defined anyway.

Closes #47 